### PR TITLE
Fix missing commands.json in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "files": [
     "pio-remote.js",
     "README.md",
-    "pio-remote-config-schema.coffee"
+    "pio-remote-config-schema.coffee",
+    "commands.json"
   ],
   "version": "0.3.1",
   "repository": {


### PR DESCRIPTION
```
16:57:03.078 [pimatic] Loading plugin: "pimatic-pio-remote" (0.3.1)
16:57:03.118 [pimatic] Cannot find module './commands.json'
16:57:03.134 [pimatic] Error: Cannot find module './commands.json'
16:57:03.134 [pimatic]>    at Function.Module._resolveFilename (module.js:338:15)
16:57:03.134 [pimatic]>    at Function.Module._load (module.js:280:25)
16:57:03.134 [pimatic]>    at Module.require (module.js:364:17)
16:57:03.134 [pimatic]>    at require (module.js:380:17)
16:57:03.134 [pimatic]>    at module.exports (/root/pimatic-git/node_modules/pimatic-pio-remote/pio-remote.js:49:22)
16:57:03.134 [pimatic]>    at PluginManager.loadPlugin (/root/pimatic-git/node_modules/pimatic/lib/plugins.coffee:86:16)
16:57:03.134 [pimatic]>    at /root/pimatic-git/node_modules/pimatic/lib/plugins.coffee:431:25
16:57:03.134 [pimatic]>    at tryCatcher (/root/pimatic-git/node_modules/pimatic/node_modules/bluebird/js/main/util.js:26:23)
16:57:03.134 [pimatic]>    at Promise._settlePromiseFromHandler (/root/pimatic-git/node_modules/pimatic/node_modules/bluebird/js/main/promise.js:507:31)
16:57:03.134 [pimatic]>    at Promise._settlePromiseAt (/root/pimatic-git/node_modules/pimatic/node_modules/bluebird/js/main/promise.js:581:18)
16:57:03.134 [pimatic]>    at Async._drainQueue (/root/pimatic-git/node_modules/pimatic/node_modules/bluebird/js/main/async.js:128:12)
16:57:03.134 [pimatic]>    at Async._drainQueues (/root/pimatic-git/node_modules/pimatic/node_modules/bluebird/js/main/async.js:133:10)
16:57:03.134 [pimatic]>    at Async.drainQueues (/root/pimatic-git/node_modules/pimatic/node_modules/bluebird/js/main/async.js:15:14)
16:57:03.134 [pimatic]>    at process._tickCallback (node.js:415:13)
```
